### PR TITLE
Fix Firestore post ordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,26 @@
+# Collaborative Thread Editor
+
+This project provides a minimal client-side editor for bilingual threads (English / Russian). It uses Firebase for real-time data sync and anonymous authentication.
+
+## Features
+
+- Thread archive listing stored threads
+- Real-time editing of posts with two columns
+- Anonymous Firebase authentication
+- Add or delete posts
+- Export thread content for Notion (copied to clipboard)
+
+## Setup
+
+1. Create a Firebase project with Firestore database.
+2. Enable anonymous authentication in the Firebase console.
+3. Copy your Firebase configuration into `index.html` and `editor.html` where the comment `// TODO: replace with your config` appears.
+4. Serve the files with any static web server or open directly if allowed.
+
+## Usage
+
+- Open `index.html` to see all threads and create a new one.
+- When editing a thread, each post has an English and Russian column. Changes are saved instantly to Firestore.
+- Use **Copy for Notion** to place the bilingual content on your clipboard.
+
+This is a basic demonstration; additional features such as inline comments or file uploads can be added as needed.

--- a/editor.html
+++ b/editor.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Thread Editor</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <!-- Firebase -->
+    <script src="https://www.gstatic.com/firebasejs/9.23.0/firebase-app-compat.js"></script>
+    <script src="https://www.gstatic.com/firebasejs/9.23.0/firebase-auth-compat.js"></script>
+    <script src="https://www.gstatic.com/firebasejs/9.23.0/firebase-firestore-compat.js"></script>
+</head>
+<body class="bg-gray-100 p-4">
+    <div class="max-w-4xl mx-auto">
+        <div class="flex justify-between items-center mb-4">
+            <h1 class="text-2xl font-bold">Thread Editor</h1>
+            <button id="export" class="bg-green-600 text-white px-3 py-1 rounded">Copy for Notion</button>
+        </div>
+        <div id="posts" class="space-y-4"></div>
+        <button id="addPost" class="mt-4 bg-blue-600 text-white px-4 py-2 rounded">Add Post</button>
+    </div>
+
+<script>
+const firebaseConfig = {
+    // TODO: replace with your config
+};
+firebase.initializeApp(firebaseConfig);
+const db = firebase.firestore();
+const auth = firebase.auth();
+auth.signInAnonymously();
+
+const params = new URLSearchParams(location.search);
+const threadId = params.get('id');
+const postsDiv = document.getElementById('posts');
+
+function postHTML(id, data) {
+    return `<div class="grid grid-cols-2 gap-2" data-id="${id}">
+        <div contenteditable class="border p-2" data-field="en">${data.en || ''}</div>
+        <div contenteditable class="border p-2" data-field="ru">${data.ru || ''}</div>
+        <button class="col-span-2 text-red-600 delete">Delete</button>
+    </div>`;
+}
+
+function savePost(el) {
+    const id = el.dataset.id;
+    const en = el.querySelector('[data-field="en"]').innerHTML;
+    const ru = el.querySelector('[data-field="ru"]').innerHTML;
+    db.collection('threads').doc(threadId).collection('posts').doc(id)
+        .set({en, ru}, {merge: true});
+}
+
+if(threadId) {
+    db.collection('threads').doc(threadId).collection('posts').orderBy('index').onSnapshot(snap => {
+        postsDiv.innerHTML = '';
+        snap.forEach(doc => {
+            const el = document.createElement('div');
+            el.innerHTML = postHTML(doc.id, doc.data());
+            postsDiv.appendChild(el.firstChild);
+        });
+    });
+}
+
+document.getElementById('addPost').onclick = async () => {
+    const ref = await db.collection('threads').doc(threadId).collection('posts').add({en:'',ru:'', index:Date.now()});
+};
+
+postsDiv.addEventListener('input', (e) => {
+    const wrapper = e.target.closest('[data-id]');
+    if(wrapper) savePost(wrapper);
+});
+
+postsDiv.addEventListener('click', (e) => {
+    if(e.target.classList.contains('delete')) {
+        const wrapper = e.target.closest('[data-id]');
+        db.collection('threads').doc(threadId).collection('posts').doc(wrapper.dataset.id).delete();
+    }
+});
+
+document.getElementById('export').onclick = () => {
+    let text = '';
+    postsDiv.querySelectorAll('[data-id]').forEach((el, i) => {
+        const en = el.querySelector('[data-field="en"]').innerText;
+        const ru = el.querySelector('[data-field="ru"]').innerText;
+        text += `${i+1}. ${en}\n${ru}\n\n`;
+    });
+    navigator.clipboard.writeText(text);
+    alert('Copied!');
+};
+</script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Collaborative Thread Editor</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <!-- Firebase -->
+    <script src="https://www.gstatic.com/firebasejs/9.23.0/firebase-app-compat.js"></script>
+    <script src="https://www.gstatic.com/firebasejs/9.23.0/firebase-auth-compat.js"></script>
+    <script src="https://www.gstatic.com/firebasejs/9.23.0/firebase-firestore-compat.js"></script>
+</head>
+<body class="bg-gray-100 p-4">
+    <div class="max-w-3xl mx-auto">
+        <h1 class="text-3xl font-bold mb-4">Thread Archive</h1>
+        <div id="threads" class="space-y-2"></div>
+        <button id="newThread" class="mt-4 bg-blue-600 text-white px-4 py-2 rounded">New Thread</button>
+    </div>
+
+    <script>
+    const firebaseConfig = {
+        // TODO: replace with your config
+    };
+    firebase.initializeApp(firebaseConfig);
+    const db = firebase.firestore();
+    const auth = firebase.auth();
+    auth.signInAnonymously();
+
+    const threadsDiv = document.getElementById('threads');
+    document.getElementById('newThread').onclick = async () => {
+        const doc = await db.collection('threads').add({created: Date.now()});
+        location.href = `editor.html?id=${doc.id}`;
+    };
+
+    db.collection('threads').orderBy('created').onSnapshot(snap => {
+        threadsDiv.innerHTML = '';
+        snap.forEach(doc => {
+            const d = doc.data();
+            const el = document.createElement('div');
+            el.innerHTML = `<a class="text-blue-600" href="editor.html?id=${doc.id}">Thread ${doc.id}</a>`;
+            threadsDiv.appendChild(el);
+        });
+    });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- retain `index` field when editing posts so Firestore ordering works

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6859fad07f508324bb7326d24982ecab